### PR TITLE
Allow searching in arrays

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -23,7 +23,7 @@
 * [Koen Punt](https://github.com/koenpunt) - Fixed a close tag at documentation.
 * [Jun Matsushita](https://github.com/jmatsushita) - Passed `extraParameters` to editable components (react-edit).
 * [Melissa Noelle](https://github.com/melissanoelle) - Pointed out a broken link.
-* [Mathieu M-Gosselin](https://github.com/mathieumg) - Fixed code snippet. #210
+* [Mathieu M-Gosselin](https://github.com/mathieumg) - Nested array search and custom casting strategies. #212
 
 ## Acknowledgments
 

--- a/packages/reactabular-search/CHANGELOG.md
+++ b/packages/reactabular-search/CHANGELOG.md
@@ -1,3 +1,9 @@
+2.0.0 / ?
+==================
+
+  * `search.multipleColumns` and `search.singleColumn` now accept a `castingStrategy` parameter to define how to cast properties when searching. By default, everything buy arrays is casted to a string.
+  * `search.matches` now traverses arrays and returns results in the same shape.
+
 1.0.0 / 2016-07-25
 ==================
 

--- a/packages/reactabular-search/README.md
+++ b/packages/reactabular-search/README.md
@@ -14,23 +14,35 @@ The Search API consists of three parts. Out of these `search.multipleColumns` an
 
 ### Search
 
-**`search.multipleColumns({ columns: [<object>], query: {<column>: <query>}, strategy: <strategy>, transform: <transform> })([<rows to query>]) => [<filtered rows>]`**
+**`search.multipleColumns({ castingStrategy: <castingStrategy>, columns: [<object>], query: {<column>: <query>}, strategy: <strategy>, transform: <transform> })([<rows to query>]) => [<filtered rows>]`**
 
 This is the highest level search function available. It expects `rows` and `columns` in the same format the `Table` uses. `query` object describes column specific search queries.
 
 It uses `infix` strategy underneath although it is possible to change it. By default it matches in a case **insensitive** manner. If you want case sensitive behavior, pass `a => a`(identity function) as `transform`.
 
-**`search.singleColumn({ columns: [<object>], searchColumn: <string>, query: <string>, strategy: <strategy>, transform: <transform> })([<rows to query>]) => [<filtered rows>]`**
+It will cast everything but arrays to a string by default. If you want a custom casting behavior, pass a custom function to `castingStrategy`.
+
+**`search.singleColumn({ castingStrategy: <castingStrategy>, columns: [<object>], searchColumn: <string>, query: <string>, strategy: <strategy>, transform: <transform> })([<rows to query>]) => [<filtered rows>]`**
 
 This is a more specialized version of `search.multipleColumns`. You can use it to search a specific column through `searchColumn` and `query`.
 
 ### Matchers
 
-**`search._columnMatches({ rows: [<object>], column: [<object>], row: <object>, strategy: <strategy>, transform: <transform> }) => <boolean>`**
+**`search._columnMatches({ query: <string>, castingStrategy: <castingStrategy>, column: <object>, row: <object>, strategy: <strategy>, transform: <transform> }) => <boolean>`**
 
 This is a function that can be used to figure out all column specific matches. It is meant only for **internal usage** of the library.
 
+When dealing with strings:
+
 **`search.matches({ value: <string>, query: <string>, strategy: <strategy>, transform: <transform> }) => [{ startIndex: <number>, length: <number> }]`**
+
+Returns an array with the matches.
+
+When dealing with arrays:
+
+**`search.matches({ value: <string>, query: [<string|[...]>], strategy: <strategy>, transform: <transform> }) => [[{ startIndex: <number>, length: <number> }], ...]`**
+
+Returns a sparse array with the same shape as the original query. If there was a match for an item, it will have the same shape as the string version above, otherwise the array will have a hole in that location.
 
 This function returns matches against the given value and query. This is particularly useful with highlighting.
 

--- a/packages/reactabular-search/src/_column_matches.js
+++ b/packages/reactabular-search/src/_column_matches.js
@@ -2,6 +2,7 @@ import strategies from './strategies';
 
 const _columnMatches = ({
   query,
+  castingStrategy = v => (Array.isArray(v) ? v : String(v)),
   column = {},
   row,
   strategy = strategies.infix,
@@ -9,7 +10,7 @@ const _columnMatches = ({
 }) => {
   const property = column.property;
   // Pick resolved value by convention
-  const resolvedValue = String(row[`_${property}`] || row[property]);
+  const resolvedValue = castingStrategy(row[`_${property}`] || row[property]);
 
   return strategy(transform(query)).evaluate(transform(resolvedValue));
 };

--- a/packages/reactabular-search/src/multiple_columns.js
+++ b/packages/reactabular-search/src/multiple_columns.js
@@ -1,12 +1,13 @@
 import singleColumn from './single_column';
 
 const multipleColumns = ({
-  columns, query, strategy, transform
+  castingStrategy, columns, query, strategy, transform
 }) => data => (
   query ?
     Object.keys(query).reduce(
       (filteredData, searchColumn) =>
         singleColumn({
+          castingStrategy,
           columns,
           searchColumn,
           query: query[searchColumn],

--- a/packages/reactabular-search/src/single_column.js
+++ b/packages/reactabular-search/src/single_column.js
@@ -1,7 +1,7 @@
 import _columnMatches from './_column_matches';
 
 const singleColumn = ({
-  columns, searchColumn = 'all', query, strategy, transform
+  castingStrategy, columns, searchColumn = 'all', query, strategy, transform
 }) => rows => {
   if (!query) {
     return rows;
@@ -14,7 +14,7 @@ const singleColumn = ({
   }
 
   return rows.filter(row => ret.filter(column => _columnMatches({
-    query, column, strategy, transform, row
+    query, castingStrategy, column, strategy, transform, row
   })).length > 0);
 };
 

--- a/packages/reactabular-search/src/strategies.js
+++ b/packages/reactabular-search/src/strategies.js
@@ -4,11 +4,30 @@ const infix = queryTerm => ({
       return false;
     }
 
+    if (Array.isArray(searchText)) {
+      return searchText.some(v => this.evaluate(v));
+    }
+
     return searchText.indexOf(queryTerm) !== -1;
   },
   matches(searchText = '') {
     if (!searchText) {
       return [];
+    }
+
+    if (Array.isArray(searchText)) {
+      return searchText.reduce(
+        (result, text, index) => {
+          const search = this.matches(text);
+
+          if (search.length) {
+            result[index] = search; // eslint-disable-line no-param-reassign
+          }
+
+          return result;
+        },
+        new Array(searchText.length)
+      );
     }
 
     const splitString = searchText.split(queryTerm);
@@ -36,11 +55,30 @@ const prefix = queryTerm => ({
       return false;
     }
 
+    if (Array.isArray(searchText)) {
+      return searchText.some(v => this.evaluate(v));
+    }
+
     return searchText.indexOf(queryTerm) === 0;
   },
   matches(searchText = '') {
     if (!searchText) {
       return [];
+    }
+
+    if (Array.isArray(searchText)) {
+      return searchText.reduce(
+        (result, text, index) => {
+          const search = this.matches(text);
+
+          if (search.length) {
+            result[index] = search; // eslint-disable-line no-param-reassign
+          }
+
+          return result;
+        },
+        new Array(searchText.length)
+      );
     }
 
     const prefixIndex = searchText.indexOf(queryTerm);

--- a/packages/reactabular-search/tests/_column_matches_test.js
+++ b/packages/reactabular-search/tests/_column_matches_test.js
@@ -48,6 +48,22 @@ describe('search._columnMatches', function () {
     expect(result).to.equal(false);
   });
 
+  it('accepts alternative casting strategy', function () {
+    const query = 'foobar';
+    const result = _columnMatches({
+      query,
+      column: {
+        property: 'demo'
+      },
+      row: {
+        demo: 'foo'
+      },
+      castingStrategy: v => `${v}bar`
+    });
+
+    expect(result).to.equal(true);
+  });
+
   it('accepts alternative transform', function () {
     const query = 'oba';
     const result = _columnMatches({
@@ -78,6 +94,21 @@ describe('search._columnMatches', function () {
     });
 
     expect(result).to.equal(true);
+  });
+
+  it('does not cast arrays to strings', function () {
+    const query = 'foo,bar';
+    const result = _columnMatches({
+      query,
+      column: {
+        property: 'demo'
+      },
+      row: {
+        demo: ['foo', 'bar']
+      }
+    });
+
+    expect(result).to.equal(false);
   });
 
   it('formats property', function () {

--- a/packages/reactabular-search/tests/multiple_columns_test.js
+++ b/packages/reactabular-search/tests/multiple_columns_test.js
@@ -79,4 +79,20 @@ describe('search.multipleColumns', function () {
 
     expect(result).to.deep.equal(rows);
   });
+
+  it('accepts alternative casting strategy', function () {
+    const query = { demo: 'foobar' };
+    const rows = [{ demo: 'foo' }, { demo: 'barfoo' }];
+    const result = multipleColumns({
+      query,
+      columns: [
+        {
+          property: 'demo'
+        }
+      ],
+      castingStrategy: v => `${v}bar`
+    })(rows);
+
+    expect(result).to.deep.equal(rows);
+  });
 });

--- a/packages/reactabular-search/tests/single_column_test.js
+++ b/packages/reactabular-search/tests/single_column_test.js
@@ -97,4 +97,21 @@ describe('search.singleColumn', function () {
 
     expect(result).to.deep.equal(rows);
   });
+
+  it('accepts alternative casting strategy', function () {
+    const query = 'foobar';
+    const rows = [{ demo: 'foo' }];
+    const result = singleColumn({
+      query,
+      columns: [
+        {
+          property: 'demo'
+        }
+      ],
+      searchColumn: 'all',
+      castingStrategy: v => `${v}bar`
+    })(rows);
+
+    expect(result).to.deep.equal(rows);
+  });
 });

--- a/packages/reactabular-search/tests/strategies_test.js
+++ b/packages/reactabular-search/tests/strategies_test.js
@@ -40,6 +40,62 @@ describe('search.strategies.infix', function () {
     expect(predicate.matches(text)).to.deep.equal(expected);
   });
 
+  it('matches arrays correctly', function () {
+    const queryTerm = 'bl';
+    const text = ['black', 'red', 'able'];
+
+    const predicate = infix(queryTerm);
+    const expected = [ // eslint-disable-line no-sparse-arrays
+      [{
+        startIndex: 0,
+        length: queryTerm.length
+      }],,
+      [{
+        startIndex: 1,
+        length: queryTerm.length
+      }]
+    ];
+
+    expect(predicate.evaluate(text)).to.equal(true);
+    expect(predicate.matches(text)).to.deep.equal(expected);
+  });
+
+  it('matches nested arrays correctly', function () {
+    const queryTerm = 'bl';
+    const text = ['orange', 'black', ['red', ['no', 'blabla', 'no']], 'able'];
+
+    const predicate = infix(queryTerm);
+    const expected = [, // eslint-disable-line no-sparse-arrays
+      [{
+        startIndex: 0,
+        length: queryTerm.length
+      }],
+      [
+        [, // eslint-disable-line no-sparse-arrays
+          [, // eslint-disable-line no-sparse-arrays
+            [
+              {
+                startIndex: 0,
+                length: queryTerm.length
+              },
+              {
+                startIndex: 3,
+                length: queryTerm.length
+              }
+            ],,
+          ]
+        ]
+      ],
+      [{
+        startIndex: 1,
+        length: queryTerm.length
+      }]
+    ];
+
+    expect(predicate.evaluate(text)).to.equal(true);
+    expect(predicate.matches(text)).to.deep.equal(expected);
+  });
+
   it('does not match', function () {
     const queryTerm = 'light';
     const text = 'dark';
@@ -61,6 +117,48 @@ describe('search.strategies.prefix', function () {
       startIndex: 0,
       length: queryTerm.length
     }];
+
+    expect(predicate.evaluate(text)).to.equal(true);
+    expect(predicate.matches(text)).to.deep.equal(expected);
+  });
+
+  it('matches arrays correctly', function () {
+    const queryTerm = 'bl';
+    const text = ['black', 'red', 'able'];
+
+    const predicate = prefix(queryTerm);
+    const expected = [ // eslint-disable-line no-sparse-arrays
+      [{
+        startIndex: 0,
+        length: queryTerm.length
+      }],,,
+    ];
+
+    expect(predicate.evaluate(text)).to.equal(true);
+    expect(predicate.matches(text)).to.deep.equal(expected);
+  });
+
+  it('matches nested arrays correctly', function () {
+    const queryTerm = 'bl';
+    const text = ['orange', 'black', ['red', ['no', 'blabla', 'no']], 'able'];
+
+    const predicate = prefix(queryTerm);
+    const expected = [, // eslint-disable-line no-sparse-arrays
+      [{
+        startIndex: 0,
+        length: queryTerm.length
+      }],
+      [
+        [, // eslint-disable-line no-sparse-arrays
+          [, // eslint-disable-line no-sparse-arrays
+            [{
+              startIndex: 0,
+              length: queryTerm.length
+            }],,
+          ]
+        ]
+      ],,
+    ];
 
     expect(predicate.evaluate(text)).to.equal(true);
     expect(predicate.matches(text)).to.deep.equal(expected);

--- a/packages/reactabular-search/tests/strategies_test.js
+++ b/packages/reactabular-search/tests/strategies_test.js
@@ -70,20 +70,18 @@ describe('search.strategies.infix', function () {
         startIndex: 0,
         length: queryTerm.length
       }],
-      [
+      [, // eslint-disable-line no-sparse-arrays
         [, // eslint-disable-line no-sparse-arrays
-          [, // eslint-disable-line no-sparse-arrays
-            [
-              {
-                startIndex: 0,
-                length: queryTerm.length
-              },
-              {
-                startIndex: 3,
-                length: queryTerm.length
-              }
-            ],,
-          ]
+          [
+            {
+              startIndex: 0,
+              length: queryTerm.length
+            },
+            {
+              startIndex: 3,
+              length: queryTerm.length
+            }
+          ],,
         ]
       ],
       [{
@@ -148,14 +146,12 @@ describe('search.strategies.prefix', function () {
         startIndex: 0,
         length: queryTerm.length
       }],
-      [
+      [, // eslint-disable-line no-sparse-arrays
         [, // eslint-disable-line no-sparse-arrays
-          [, // eslint-disable-line no-sparse-arrays
-            [{
-              startIndex: 0,
-              length: queryTerm.length
-            }],,
-          ]
+          [{
+            startIndex: 0,
+            length: queryTerm.length
+          }],,
         ]
       ],,
     ];

--- a/packages/reactabular/CHANGELOG.md
+++ b/packages/reactabular/CHANGELOG.md
@@ -1,3 +1,11 @@
+5.3.0 / ?
+==================
+
+## reactabular-search
+
+  * `search.multipleColumns` and `search.singleColumn` now accept a `castingStrategy` parameter to define how to cast properties when searching. By default, everything buy arrays is casted to a string.
+  * `search.matches` now traverses arrays and returns results in the same shape.
+
 5.2.1 / 2016-09-30
 ==================
 


### PR DESCRIPTION
As discussed in #211.

I think the fact that it no longer automatically casts arrays to strings could be considered a breaking change, if people still leveraged the fact that `["a", "b", "c"]` was becoming `"a,b,c"`.

I didn't see anything about squashing and such, but of course I will abide by whatever the approach is here!