### PR TITLE
Fixed bug: Toggling column with filter set

### DIFF
--- a/docs/examples/all-features.md
+++ b/docs/examples/all-features.md
@@ -396,10 +396,11 @@ class AllFeaturesTable extends React.Component {
   }
   onToggleColumn(columnIndex) {
     const columns = cloneDeep(this.state.columns);
-
-    columns[columnIndex].visible = !columns[columnIndex].visible;
-
-    this.setState({ columns });
+    const column = columns[columnIndex];
+    column.visible = !column.visible;
+    const query = cloneDeep(this.state.query);
+    delete query[column.property];
+    this.setState({ columns, query });
   }
 }
 

--- a/packages/reactabular-search-columns/src/index.jsx
+++ b/packages/reactabular-search-columns/src/index.jsx
@@ -10,7 +10,7 @@ const SearchColumns = ({ columns, query, onChange }) => {
 
   return (
     <tr>
-      {columns.map((column, i) => (
+      {columns.map((column) => (
         <th key={`${column.property}-column-filter`} className="column-filter">
           {column && column.property ?
             <input

--- a/packages/reactabular-search-columns/src/index.jsx
+++ b/packages/reactabular-search-columns/src/index.jsx
@@ -11,14 +11,14 @@ const SearchColumns = ({ columns, query, onChange }) => {
   return (
     <tr>
       {columns.map((column, i) => (
-        <th key={`${i}-column-filter`} className="column-filter">
+        <th key={`${column.property}-column-filter`} className="column-filter">
           {column && column.property ?
             <input
               onChange={onQueryChange}
               className="column-filter-input"
               name={column.property}
               placeholder={column.filterPlaceholder || ''}
-              value={query[i]}
+              value={query[column.property]}
             />
           : ''}
         </th>


### PR DESCRIPTION
Few changes were made. The main problem is the key value of th which is based on the index. As a result, the textbox within th does not get updated even when columns and query props change.

There was another bug that got resolved with this. It is related to the filtering of data in the demo. Removing the filter from the query object in state while toggling the column fixed the issue.