### PR TITLE
Update reactabular-table version in peerDependencies

### DIFF
--- a/packages/reactabular-sticky/package.json
+++ b/packages/reactabular-sticky/package.json
@@ -41,6 +41,6 @@
   "peerDependencies": {
     "lodash": ">= 3.0.0 < 5.0.0",
     "react": ">= 0.11.2 < 16.0.0",
-    "reactabular-table": "^5.1.0"
+    "reactabular-table": "^6.0.0"
   }
 }


### PR DESCRIPTION
See this error when trying to update to Reactabular 6.0.0:

```
❯ npm i
kao@21.8.2 /Users/sapegin/izumi/kao
└─┬ reactabular@6.0.0
  ├── reactabular-highlight@6.0.0
  ├── reactabular-resizable@6.0.0
  ├─┬ reactabular-resolve@6.0.0
  │ └── reactabular-utils@6.0.0
  ├── reactabular-search@6.0.0
  ├── reactabular-search-columns@6.0.0
  ├── reactabular-search-field@6.0.0
  ├── reactabular-select@6.0.0
  ├── reactabular-sort@6.0.0
  ├── reactabular-sticky@6.0.0
  └── UNMET PEER DEPENDENCY reactabular-table@6.0.0

npm WARN reactabular-sticky@6.0.0 requires a peer of reactabular-table@^5.1.0 but none was installed.
```