### PR TITLE
fix(easy) -`onRow` accepts `row, { rowIndex, rowKey }` per `table` breaking change

### DIFF
--- a/packages/reactabular-easy/src/table.jsx
+++ b/packages/reactabular-easy/src/table.jsx
@@ -302,8 +302,8 @@ class EasyTable extends React.Component {
 
     return movedColumns;
   }
-  onRow(row, rowIndex) {
-    const { className, ...props } = this.props.onRow(row, rowIndex);
+  onRow(row, { rowIndex, rowKey }) {
+    const { className, ...props } = this.props.onRow(row, { rowIndex, rowKey });
 
     return {
       className: mergeClassNames(className, row.selected && 'selected-row'),


### PR DESCRIPTION
EasyTable `onRow` accepts `row, { rowIndex, rowKey }` instead of `row, rowIndex` as per changed Table.

This effectively fixes `Uncaught TypeError: Cannot read property Id of undefined` on row click in the Easy Version example.