### PR TITLE
Allow overriding overflow for sticky table

### DIFF
--- a/packages/reactabular-sticky/src/body.js
+++ b/packages/reactabular-sticky/src/body.js
@@ -23,7 +23,7 @@ class Body extends React.Component {
         style: {
           display: 'block',
           overflow: 'auto',
-          paddingRight: scrollOffset
+          paddingRight: scrollOffset,
           ...style || {},
         },
         // Expand onScroll as otherwise the logic won't work

--- a/packages/reactabular-sticky/src/body.js
+++ b/packages/reactabular-sticky/src/body.js
@@ -24,7 +24,7 @@ class Body extends React.Component {
           display: 'block',
           overflow: 'auto',
           paddingRight: scrollOffset,
-          ...style || {},
+          ...style || {}
         },
         // Expand onScroll as otherwise the logic won't work
         onScroll: (e) => {

--- a/packages/reactabular-sticky/src/body.js
+++ b/packages/reactabular-sticky/src/body.js
@@ -21,10 +21,10 @@ class Body extends React.Component {
           this.ref = body && body.getRef();
         },
         style: {
-          ...style || {},
           display: 'block',
           overflow: 'auto',
           paddingRight: scrollOffset
+          ...style || {},
         },
         // Expand onScroll as otherwise the logic won't work
         onScroll: (e) => {


### PR DESCRIPTION
I'm using external implementation of scroll bar and it's impossible to hide the tbody scroll bar.