### PR TITLE
Fix false negative rowkey check.

### DIFF
--- a/packages/reactabular-table/__tests__/resolve_row_key_test.js
+++ b/packages/reactabular-table/__tests__/resolve_row_key_test.js
@@ -44,4 +44,21 @@ describe('table.resolveRowKey', function () {
 
     expect(resolveRowKey({ rowData, rowIndex, rowKey })).toEqual(`${rowIndex}-row`);
   });
+
+  it('allows rowKey to be a getter', function () {
+    class Row {
+      constructor() {
+        this.val = 'bar';
+      }
+      get foo() {
+        return this.val;
+      }
+    }
+
+    const rowIndex = 0;
+    const rowKey = 'foo';
+    const rowData = new Row();
+
+    expect(resolveRowKey({ rowData, rowIndex, rowKey })).toEqual('bar-row');
+  });
 });

--- a/packages/reactabular-table/src/resolve-row-key.js
+++ b/packages/reactabular-table/src/resolve-row-key.js
@@ -5,7 +5,7 @@ function resolveRowKey({ rowData, rowIndex, rowKey }) {
     return `${rowKey({ rowData, rowIndex })}-row`;
   } else if (process.env.NODE_ENV !== 'production') {
     // Arrays cannot have rowKeys by definition so we have to go by index there.
-    if (!isArray(rowData) && !{}.hasOwnProperty.call(rowData, rowKey)) {
+    if (!isArray(rowData) && !rowData[rowKey]) {
       console.warn( // eslint-disable-line no-console
         'Table.Body - Missing valid rowKey!',
         rowData,


### PR DESCRIPTION
Check using Object.hasOwnProperty would warn erroneously
for valid object with getters, for example Immutable records.