### PR TITLE
virtualized can use props.style.maxHeight, #276

### DIFF
--- a/packages/reactabular-virtualized/README.md
+++ b/packages/reactabular-virtualized/README.md
@@ -16,6 +16,7 @@ import { generateRows } from './helpers';
 
 const columns = [
   {
+    property: 'id',
     props: {
       style: { minWidth: 50 }
     },
@@ -163,7 +164,101 @@ class VirtualizedTable extends React.Component {
 
 <VirtualizedTable />
 ```
-
 ## Scrolling to Index
 
 `Virtualized.Body` `ref` exposes `scrollTo` method for scrolling through index. If you want to scroll based on some field value, search the dataset first and pass the resulting index here.
+
+## Define the height of table
+Please note `height` of `<Virtualized.Body>` must be defined. If `height` is not defined, `style.maxHeight` will be used. In below example, we use `style.maxHeight` instead of `height`,
+
+```jsx
+/*
+import React from 'react';
+import * as Sticky from 'reactabular-sticky';
+import * as Virtualized from 'reactabular-virtualized';
+
+import { generateRows } from './helpers';
+*/
+
+const columns = [
+  {
+    property: 'id',
+    props: {
+      style: { minWidth: 50 }
+    },
+    header: {
+      label: 'Index'
+    }
+  },
+  {
+    property: 'name',
+    props: {
+      style: { minWidth: 300 }
+    },
+    header: {
+      label: 'Name'
+    }
+  }
+];
+
+const rows = generateRows(1000);
+
+class VirtualizedTable extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      rows,
+      columns
+    };
+
+    this.tableHeader = null;
+    this.tableBody = null;
+  }
+  componentDidMount() {
+    // We have refs now. Force update to get those to Header/Body.
+    this.forceUpdate();
+  }
+  render() {
+    return (
+      <div>
+        <Table.Provider
+          className="pure-table pure-table-striped"
+          columns={columns}
+          components={{
+            body: {
+              wrapper: Virtualized.BodyWrapper,
+              row: Virtualized.BodyRow
+            }
+          }}
+        >
+          <Sticky.Header
+            style={{
+              maxWidth: 800
+            }}
+            ref={tableHeader => {
+              this.tableHeader = tableHeader && tableHeader.getRef();
+            }}
+            tableBody={this.tableBody}
+          />
+
+          <Virtualized.Body
+            rows={rows}
+            rowKey="id"
+            style={{
+              maxWidth: 800,
+              maxHeight: 400
+            }}
+            ref={tableBody => {
+              this.tableBody = tableBody && tableBody.getRef();
+            }}
+            tableHeader={this.tableHeader}
+          />
+        </Table.Provider>
+      </div>
+    );
+  }
+}
+
+<VirtualizedTable />
+```

--- a/packages/reactabular-virtualized/src/body.js
+++ b/packages/reactabular-virtualized/src/body.js
@@ -25,8 +25,17 @@ class VirtualizedBody extends React.Component {
   componentDidUpdate() {
     this.checkMeasurements();
   }
+
+  getHeight(optionalProps) {
+    // If `optionalProps` is defined, we use `optionalProps` instead of `this.props`.
+    const props = optionalProps || this.props;
+    // If `props.height` is not defined, we use `props.style.maxHeight` instead.
+    return props.height || props.style.maxHeight;
+  }
+
   componentWillReceiveProps(nextProps) {
-    if (!isEqual(this.props.rows, nextProps.rows) || this.props.height !== nextProps.height) {
+    if (!isEqual(this.props.rows, nextProps.rows)
+        || this.getHeight() !== this.getHeight(nextProps)) {
       if (process.env.NODE_ENV !== 'production' && window.LOG_VIRTUALIZED) {
         console.log('invalidating measurements'); // eslint-disable-line no-console
       }
@@ -34,7 +43,7 @@ class VirtualizedBody extends React.Component {
       const rows = calculateRows({
         scrollTop: this.scrollTop,
         measuredRows: this.measuredRows,
-        height: nextProps.height,
+        height: this.getHeight(nextProps),
         rowKey: nextProps.rowKey,
         rows: nextProps.rows
       });
@@ -122,7 +131,7 @@ class VirtualizedBody extends React.Component {
             calculateRows({
               scrollTop,
               measuredRows: this.measuredRows,
-              height: this.props.height,
+              height: this.getHeight(),
               rowKey: this.props.rowKey,
               rows: this.props.rows
             })
@@ -160,7 +169,7 @@ class VirtualizedBody extends React.Component {
         const rows = calculateRows({
           scrollTop: this.scrollTop,
           measuredRows: this.measuredRows,
-          height: this.props.height,
+          height: this.getHeight(),
           rowKey: this.props.rowKey,
           rows: this.props.rows
         });


### PR DESCRIPTION
height will be used if defined, or else fallback to style.maxHeight

tested by applying below patch and `npm run start`,
```diff
diff --git a/docs/drag-and-drop/with-virtualization.md b/docs/drag-and-drop/with-virtualization.md
index 46c3f4c..872881e 100644
--- a/docs/drag-and-drop/with-virtualization.md
+++ b/docs/drag-and-drop/with-virtualization.md
@@ -104,6 +104,7 @@ class VirtualizedTable extends React.Component {
     super(props);
 
     this.state = {
+      myHeight: 400,
       rows,
       columns
     };
@@ -118,9 +119,17 @@ class VirtualizedTable extends React.Component {
     // We have refs now. Force update to get those to Header/Body.
     this.forceUpdate();
   }
+  
+  clickMe() {
+     this.setState({
+      myHeight: this.state.myHeight===400? 200:400
+     })
+  }
+
   render() {
     return (
       <div>
+        <button onClick={this.clickMe.bind(this) }>Click Me</button>
         <Table.Provider
           className="pure-table pure-table-striped"
           columns={columns}
@@ -145,9 +154,9 @@ class VirtualizedTable extends React.Component {
             rows={this.state.rows}
             rowKey="id"
             style={{
-              maxWidth: 800
+              maxWidth: 800,
+              maxHeight: this.state.myHeight
             }}
-            height={400}
             ref={tableBody => {
               this.tableBody = tableBody && tableBody.getRef();
             }}
```
