### PR TITLE
fixed: sticky cells not aligned with header if scroll to table body right end #259

### DIFF
--- a/packages/reactabular-sticky/README.md
+++ b/packages/reactabular-sticky/README.md
@@ -116,6 +116,7 @@ class StickyTable extends React.Component {
         <Sticky.Body
           rows={rows}
           rowKey="id"
+          scrollLeftLimitOffset={0}
           style={{
             maxWidth: 800,
             maxHeight: 400
@@ -132,3 +133,5 @@ class StickyTable extends React.Component {
 
 <StickyTable />
 ```
+
+Please note `<Sticky.Body />` has an optional attribute `scrollLeftLimitOffset` which could prevent the user scroll the content to the right end of table, so header and cells will always be in alignment.

--- a/packages/reactabular-sticky/src/body.js
+++ b/packages/reactabular-sticky/src/body.js
@@ -9,7 +9,7 @@ class Body extends React.Component {
     this.ref = null;
   }
   render() {
-    const { style, tableHeader, onScroll, ...props } = this.props;
+    const { style, tableHeader, onScroll, scrollLeftLimitOffset, ...props } = this.props;
     const tableHeaderWidth = tableHeader ? tableHeader.clientWidth : 0;
     const tableBodyWidth = this.ref ? this.ref.clientWidth : 0;
     const scrollOffset = tableHeaderWidth - tableBodyWidth || 0;
@@ -30,7 +30,21 @@ class Body extends React.Component {
         onScroll: (e) => {
           onScroll && onScroll(e);
 
-          const { target: { scrollLeft } } = e;
+          const { target: { scrollLeft, scrollWidth, clientWidth } } = e;
+
+          // force move the scrollLeft back `scrollLeftLimitOffset` pixedl
+          // if `props.scrollLeftLimitOffset` is defined
+          // @see https://github.com/reactabular/reactabular/issues/259
+          // "cell in sticky not aligned with header when scrolling to the right end"
+          // so the solution is as simple as NOT to scroll to the right end
+          // scticky header doesn't have the problem.
+          if (scrollLeftLimitOffset &&
+              scrollLeftLimitOffset > 0 &&
+              scrollLeft > scrollWidth - clientWidth - scrollLeftLimitOffset) {
+            /* eslint-disable no-param-reassign */
+            e.target.scrollLeft = scrollWidth - clientWidth - scrollLeftLimitOffset;
+            /* eslint-enable */
+          }
 
           if (tableHeader) {
             tableHeader.scrollLeft = scrollLeft;
@@ -47,7 +61,8 @@ class Body extends React.Component {
 Body.propTypes = {
   style: React.PropTypes.any,
   tableHeader: React.PropTypes.any,
-  onScroll: React.PropTypes.func
+  onScroll: React.PropTypes.func,
+  scrollLeftLimitOffset: React.PropTypes.number
 };
 
 export default Body;


### PR DESCRIPTION
This solution add a optional parameter to stop user scrolling to the table body right edge.

Solved #259 