### PR TITLE
draggable-row: don't create new component type

### DIFF
--- a/packages/reactabular-dnd/src/draggable-row.js
+++ b/packages/reactabular-dnd/src/draggable-row.js
@@ -86,10 +86,12 @@ DraggableRow.propTypes = {
   rowId: React.PropTypes.any.isRequired
 };
 
+const SourceTargetDraggableRow = dragSource(dropTarget(DraggableRow));
+
 const draggableRow = (_parent) => {
   function draggable(children) {
     return React.createElement(
-      dragSource(dropTarget(DraggableRow)),
+      SourceTargetDraggableRow,
       {
         _parent,
         ...children


### PR DESCRIPTION
Problem
---

Currently, this creates a new component "type" for each render. This causes React's reconciliation algorithm to re-render the entire row when cell contents change.

This isn't ideal for controlled components, like `<input>`s, because they will lose focus with each keypress.

Solution
---

Define the component class once and reuse it. I think this is equivalent—please let me know if I'm missing anything! :)