### PR TITLE
Bumped Jest version to 19.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "git-prepush-hook": "^1.0.2",
     "html-loader": "^0.4.4",
     "html-webpack-plugin": "^2.28.0",
-    "jest": "^18.1.0",
+    "jest": "^19.0.2",
     "lerna": "2.0.0-beta.37",
     "lodash": "^4.17.4",
     "prop-types": "^15.5.8",


### PR DESCRIPTION
The previous version seems to have used React.PropTypes, so corresponding warnings were output during test runs. To remove these warnings and have a smooth transition to React 16, I have upgraded the Jest version.