### PR TITLE
#307 fix resizing feature in order to support resizing of nested columns

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -35,6 +35,7 @@
 * [Chen Bin](https://github.com/redguardtoo) - Support `props.style.maxHeight` at virtualization. ##277
 * [Daniel Johnson](https://github.com/danielj41) - Don't create a new component type on render to avoid issues with controlled components. #287
 * [José Diaz Seng](https://github.com/joseds) - Add styled-components example. Fix to work with React 15.5. Updated Jest. #293, #297, #298
+* [Junho Park](https://github.com/cnaa97) - Fix Nested Columns more then two children. Enhancement resizing columns for nested column. #301, #307
 
 ## Acknowledgments
 

--- a/packages/reactabular-resizable/__tests__/helper_test.js
+++ b/packages/reactabular-resizable/__tests__/helper_test.js
@@ -27,4 +27,90 @@ describe('helper', function () {
 
     expect(helper.initialize(columns)).toEqual(expected);
   });
+
+  it('With nested columns, class names only leaf column correctly', function () {
+    const column = {
+      property: 'demo1',
+      props: {
+        className: 'demo1'
+      },
+      header: {
+        label: 'Demo1'
+      }
+    };
+    const childrenColumn = {
+      property: 'boo',
+      props: {
+        className: 'boo'
+      },
+      header: {
+        label: 'Boo'
+      }
+    };
+    const column2 = {
+      property: 'demo2',
+      props: {
+        className: 'demo2'
+      },
+      header: {
+        label: 'Demo2'
+      },
+      children: [
+        {
+          property: 'cha',
+          props: {
+            className: 'cha'
+          },
+          header: {
+            label: 'cha'
+          }
+        },
+        childrenColumn
+      ]
+    };
+    const columns = [column, column2];
+    const expected = [
+      Object.assign(column, {
+        props: {
+          className: 'demo1 column-foo-bar'
+        }
+      }),
+      {
+        property: 'demo2',
+        props: {
+          className: 'demo2'
+        },
+        header: {
+          label: 'Demo2'
+        },
+        children: [
+          {
+            property: 'cha',
+            props: {
+              className: 'cha column-foo-bar'
+            },
+            header: {
+              label: 'cha'
+            }
+          },
+          {
+            property: 'boo',
+            props: {
+              className: 'boo column-foo-bar'
+            },
+            header: {
+              label: 'Boo'
+            }
+          }
+        ]
+      }
+    ];
+
+    const helper = resizableHelper({
+      globalId: 'foo',
+      getId: () => 'bar'
+    });
+
+    expect(helper.initialize(columns)).toEqual(expected);
+  });
 });


### PR DESCRIPTION
I wrote a issue about resizing. 

I found bug that resizing table with nested columns, Resizing feature doesn't work. 

because resizing helper could detect only first depth column, except children.

In my code, There are `leafIndex` variable. leaf index is to distinguish either a column is leaf or not.

![screen shot 2017-06-21 at 5 55 55 pm](https://user-images.githubusercontent.com/7259107/27375680-e9acc9c4-56aa-11e7-9955-aeaa67f5faaa.png)

Thanks.