### PR TITLE
fix virtualization propType warning

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -36,6 +36,7 @@
 * [Daniel Johnson](https://github.com/danielj41) - Don't create a new component type on render to avoid issues with controlled components. #287
 * [José Diaz Seng](https://github.com/joseds) - Add styled-components example. Fix to work with React 15.5. Updated Jest. #293, #297, #298
 * [Junho Park](https://github.com/cnaa97) - Fix Nested Columns more then two children. Enhancement resizing columns for nested column. #301, #307
+* [R Sloan](https://github.com/rnsloan) - Fixed virtualization propType warning
 
 ## Acknowledgments
 

--- a/packages/reactabular-virtualized/src/__tests__/prop_type_validation.js
+++ b/packages/reactabular-virtualized/src/__tests__/prop_type_validation.js
@@ -1,0 +1,33 @@
+import { heightPropCheck } from '../body.js';
+
+describe('height propType validator', function () {
+  it('has no error when height is a number', function () {
+    expect(
+      heightPropCheck({ height: 50 }, 'height', 'VirtualizedBody')
+    ).toBeUndefined();
+  });
+
+  it('has no error when style.maxHeight is a number', function () {
+    expect(
+      heightPropCheck({ style: { maxHeight: 50 } }, 'height', 'VirtualizedBody')
+    ).toBeUndefined();
+  });
+
+  it('has an error when height and style.maxHeight are not provided', function () {
+    expect(
+      heightPropCheck({}, 'height', 'VirtualizedBody')
+    ).toThrow();
+  });
+
+  it('has an error when height is not a number', function () {
+    expect(
+      heightPropCheck({ height: '50px' }, 'height', 'VirtualizedBody')
+    ).toThrow();
+  });
+
+  it('has an error when style.maxHeight is not a number', function () {
+    expect(
+      heightPropCheck({ style: { maxHeight: '50px' } }, 'height', 'VirtualizedBody')
+    ).toThrow();
+  });
+});

--- a/packages/reactabular-virtualized/src/body.js
+++ b/packages/reactabular-virtualized/src/body.js
@@ -1,6 +1,5 @@
 import { isEqual } from 'lodash';
 import React from 'react';
-import PropTypes from 'prop-types';
 import { Body } from 'reactabular-sticky';
 import { resolveRowKey } from 'reactabular-table';
 import { bodyChildContextTypes } from './types';
@@ -195,9 +194,20 @@ class VirtualizedBody extends React.Component {
 VirtualizedBody.defaultProps = Body.defaultProps;
 VirtualizedBody.propTypes = {
   ...Body.propTypes,
-  height: PropTypes.number.isRequired
+  height: heightPropCheck
 };
 VirtualizedBody.childContextTypes = bodyChildContextTypes;
+
+/* eslint-disable consistent-return */
+export function heightPropCheck(props, propName, componentName) {
+  if (
+    (typeof props[propName] !== 'number') &&
+    (!props.style || typeof props.style.maxHeight !== 'number')
+    ) {
+    return new Error(`height or style.maxHeight of type 'number' is marked as required in ${componentName}`);
+  }
+}
+/* eslint-enable consistent-return */
 
 function getInitialState() {
   return {


### PR DESCRIPTION
#277 introduced the ability to use `style.maxHeight` instead of `height` but the propTypes are still producing a warning when the `height` prop is not present.