### PR TITLE
chore: Update treetabular

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11623,9 +11623,9 @@
       "dev": true
     },
     "treetabular": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/treetabular/-/treetabular-3.4.0.tgz",
-      "integrity": "sha512-p76eSPbJf9HfcilHj4H/gaKKFo6mIWWCWN6GIv0XahS30RLZmbtf8iidY+dcJKBEXBhl8yHWo6j5nLHoqTHXwQ==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/treetabular/-/treetabular-3.5.0.tgz",
+      "integrity": "sha512-fuyZ3DD9sQCtoNBYyRHzRp0EeV+mslHfl887r23NcjksBRT3XbKPxpJUbIijwj/baBUJtUtf/nn55X+iCItn9Q==",
       "dev": true
     },
     "trim-newlines": {

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "styled-components": "^2.2.0",
     "stylesheet-helpers": "^0.2.2",
     "table-resolver": "^3.2.0",
-    "treetabular": "^3.4.0",
+    "treetabular": "^3.5",
     "url-loader": "^0.6.2",
     "uuid": "^3.0.1",
     "webpack": "^3.6.0",


### PR DESCRIPTION
The new version of tabular uses React 16.x whereas the old one uses 15.x.