### PR TITLE
Fix example import statement for reactabular-table

### DIFF
--- a/packages/reactabular-table/README.md
+++ b/packages/reactabular-table/README.md
@@ -6,7 +6,7 @@ Reactabular provides three components: `Table.Provider`, `Table.Header`, and `Ta
 
 ```jsx
 /*
-import { Table } from 'reactabular-table';
+import * as Table from 'reactabular-table';
 */
 
 const rows = [


### PR DESCRIPTION
This just caught me as someone new to the library.  I did a quick edit using the GitHub editor.  This is a quick docs-only fix, so I'm not sure if the contribution guidelines all still apply.

thanks!