### PR TITLE
Check if window is defined before checking LOG_VIRTUALIZED

### DIFF
--- a/packages/reactabular-virtualized/src/body.js
+++ b/packages/reactabular-virtualized/src/body.js
@@ -40,7 +40,7 @@ class VirtualizedBody extends React.Component {
   componentWillReceiveProps(nextProps) {
     if (!isEqual(this.props.rows, nextProps.rows)
         || this.getHeight() !== this.getHeight(nextProps)) {
-      if (process.env.NODE_ENV !== 'production' && window.LOG_VIRTUALIZED) {
+      if (process.env.NODE_ENV !== 'production' && typeof window !== 'undefined' && window.LOG_VIRTUALIZED) {
         console.log('invalidating measurements'); // eslint-disable-line no-console
       }
 
@@ -93,7 +93,7 @@ class VirtualizedBody extends React.Component {
       ]
     }));
 
-    if (process.env.NODE_ENV !== 'production' && window.LOG_VIRTUALIZED) {
+    if (process.env.NODE_ENV !== 'production' && typeof window !== 'undefined' && window.LOG_VIRTUALIZED) {
       console.log( // eslint-disable-line no-console
         'rendering', rowsToRender.length, '/', rows.length,
         'rows to render', rowsToRender,

--- a/packages/reactabular-virtualized/src/calculate-rows.js
+++ b/packages/reactabular-virtualized/src/calculate-rows.js
@@ -18,7 +18,7 @@ const calculateRows = ({
     startIndex + amountOfRowsToRender
   );
 
-  if (process.env.NODE_ENV !== 'production' && window.LOG_VIRTUALIZED) {
+  if (process.env.NODE_ENV !== 'production' && typeof window !== 'undefined' && window.LOG_VIRTUALIZED) {
     console.log( // eslint-disable-line no-console
       'update rows to render',
       'scroll top', scrollTop,
@@ -48,7 +48,7 @@ const calculateRows = ({
     0
   );
 
-  if (process.env.NODE_ENV !== 'production' && window.LOG_VIRTUALIZED) {
+  if (process.env.NODE_ENV !== 'production' && typeof window !== 'undefined' && window.LOG_VIRTUALIZED) {
     console.log( // eslint-disable-line no-console
       'average height', averageHeight,
       'body height', height,


### PR DESCRIPTION
Fixed an issue with Server Side Rendering. Virtualized logging can still be enabled in the browser. Can't see any problematic side effects.