### PR TITLE
fix typo in lodash import in examples/add-features.md

### DIFF
--- a/docs/examples/all-features.md
+++ b/docs/examples/all-features.md
@@ -5,7 +5,7 @@ The following example uses majority of Reactabular's features and combines them 
 import React from 'react';
 import { compose } from 'redux';
 import {
-  cloneDeep, findIndex, orderBy, keys, values, transforms
+  cloneDeep, findIndex, orderBy, keys, values, transform
 } from 'lodash';
 import * as Table from 'reactabular-table';
 import * as search from 'searchtabular';


### PR DESCRIPTION
In the example code, there is a typo in the import section.  "transforms" from lodash should be singular, I have changed it to "transform".