### PR TITLE
Added option to use a container for the scrolling in virtualization

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -37,6 +37,7 @@
 * [José Diaz Seng](https://github.com/joseds) - Add styled-components example. Fix to work with React 15.5. Updated Jest. #293, #297, #298
 * [Junho Park](https://github.com/cnaa97) - Fix Nested Columns more then two children. Enhancement resizing columns for nested column. #301, #307
 * [R Sloan](https://github.com/rnsloan) - Fixed virtualization propType warning
+* [Pearce Keesling](https://github.com/keeslinp) - Added option to use container for scrolling in virtualization
 
 ## Acknowledgments
 

--- a/packages/reactabular-virtualized/README.md
+++ b/packages/reactabular-virtualized/README.md
@@ -162,6 +162,143 @@ class VirtualizedTable extends React.Component {
 <VirtualizedTable />
 ```
 
+## Scrolling within a container
+
+By passing in a function as `container` which returns a reference to a container to `Virtualized.Body`, you can use the scrollbar of a surrounding element as the scroll for virtualization. This might be useful if you want to render multiple containers in the same scrolling area, or if you want the table to scroll along with the rest of your page.
+```jsx
+/*
+import React from 'react';
+import * as Sticky from 'reactabular-sticky';
+import * as Virtualized from 'reactabular-virtualized';
+import * as resolve from 'table-resolver';
+
+import { generateRows } from './helpers';
+*/
+
+const columns = [
+  {
+    property: 'id',
+    props: {
+      style: { minWidth: 50 }
+    },
+    header: {
+      label: 'Index'
+    },
+    cell: {
+      formatters: [
+        (value, { rowIndex }) => <span>{rowIndex}</span>
+      ]
+    }
+  },
+  {
+    property: 'name',
+    props: {
+      style: { minWidth: 300 }
+    },
+    header: {
+      label: 'Name'
+    }
+  },
+  {
+    property: 'age',
+    props: {
+      style: { minWidth: 100 }
+    },
+    header: {
+      label: 'Age'
+    }
+  },
+  {
+    property: 'company',
+    props: {
+      style: { minWidth: 400 }
+    },
+    header: {
+      label: 'Company'
+    }
+  },
+  {
+    property: 'product',
+    props: {
+      style: { minWidth: 400 }
+    },
+    header: {
+      label: 'Product'
+    }
+  }
+];
+
+const schema = {
+  type: 'object',
+  properties: {
+    id: {
+      type: 'string'
+    },
+    name: {
+      type: 'string'
+    },
+    product: {
+      type: 'string'
+    },
+    company: {
+      type: 'string'
+    },
+    age: {
+      type: 'integer'
+    }
+  },
+  required: ['id', 'name', 'product', 'company', 'age']
+};
+// Resolving indices is an optional step. You can skip it if you don't
+// rely on rowIndex anywhere. But if you do, it's good to calculate and
+// include to the data. Reactabular's rendering logic is able to pick it
+// up by convention (`_index` field).
+const rows = resolve.resolve({ columns })(generateRows(1000, schema));
+
+class VirtualizedTable extends React.Component {
+  render() {
+    return (
+      <div>
+       <div ref={(ref) => this.container = ref} style={{ height: '500px', overflow: 'auto' }}>
+            {([1, 2, 3]).map(count => 
+            <Table.Provider
+              key={count}
+              className="pure-table pure-table-striped"
+              columns={columns}
+              style={{ margin: '20px', }}
+              renderers={{
+                body: {
+                  wrapper: Virtualized.BodyWrapper,
+                  row: Virtualized.BodyRow
+                }
+              }}
+            >
+              <Table.Header
+                style={{
+                  maxWidth: 800
+                }}
+              />
+
+              <Virtualized.Body
+                container={() => this.container}
+                rows={rows}
+                rowKey="id"
+                style={{
+                  maxWidth: 800
+                }}
+                height={400}
+              />
+            </Table.Provider>
+            )}
+        </div>
+      </div>
+    );
+  }
+}
+
+<VirtualizedTable />
+```
+
 ## Scrolling to Index
 
 `Virtualized.Body` `ref` exposes `scrollTo` method for scrolling through index. If you want to scroll based on some field value, search the dataset first and pass the resulting index here.

--- a/packages/reactabular-virtualized/src/__tests__/body_test.js
+++ b/packages/reactabular-virtualized/src/__tests__/body_test.js
@@ -1,0 +1,18 @@
+/* eslint-disable react/prop-types */
+import React from 'react';
+import { shallow } from 'enzyme';
+import { expect } from 'chai';
+import { Body as StickyBody } from 'reactabular-sticky';
+import { Body as TableBody } from 'reactabular-table';
+import Body from '../body.js';
+
+describe('Virtualized.Body', () => {
+  it('should render Sticky Body normally', () => {
+    const wrapper = shallow(<Body height={100} rows={[]}/>);  
+    expect(wrapper.find(StickyBody)).to.have.length(1);
+  });
+  it('should render Table Body normally', () => {
+    const wrapper = shallow(<Body container={() => {}} rows={[]}/>);  
+    expect(wrapper.find(TableBody)).to.have.length(1);
+  });
+});

--- a/packages/reactabular-virtualized/src/__tests__/calculate-rows_test.js
+++ b/packages/reactabular-virtualized/src/__tests__/calculate-rows_test.js
@@ -1,0 +1,49 @@
+import { expect } from 'chai';
+import calculateRows from '../calculate-rows';
+import calculateAverageHeight from '../calculate-average-height';
+
+jest.mock('../calculate-average-height');
+
+describe('calculateRows', () => {
+  it('should return null if no rows are in view', () => {
+    calculateAverageHeight.mockReturnValueOnce(10);
+    expect(calculateRows({
+      height: 500,
+      rows: [0, 1, 2, 3, 4, 5, 6, 7, 8],
+      scrollTop: -520
+    })).to.be.null;
+  });
+  it('should return the number of rows that fit in the view', () => {
+    calculateAverageHeight.mockReturnValueOnce(50);
+    expect(calculateRows({
+      height: 500,
+      rows: [0, 1, 2, 3, 4, 5, 6, 7, 8],
+      scrollTop: 0
+    })).to.have.property('amountOfRowsToRender', 12);
+  });
+
+  it('should not have startIndex lower than zero', () => {
+    calculateAverageHeight.mockReturnValueOnce(10);
+    expect(calculateRows({
+      height: 500,
+      rows: [0, 1, 2, 3, 4, 5, 6, 7, 8],
+      scrollTop: -100
+    })).to.have.property('startIndex', 0);
+  });
+
+  it('should only show extra row when on an even index', () => {
+    calculateAverageHeight.mockReturnValueOnce(10);
+    expect(calculateRows({
+      height: 500,
+      rows: [0, 1, 2, 3, 4, 5, 6, 7, 8],
+      scrollTop: 10
+    })).to.have.property('showExtraRow', false);
+
+    calculateAverageHeight.mockReturnValueOnce(10);
+    expect(calculateRows({
+      height: 500,
+      rows: [0, 1, 2, 3, 4, 5, 6, 7, 8],
+      scrollTop: 20
+    })).to.have.property('showExtraRow', true);
+  });
+});

--- a/packages/reactabular-virtualized/src/__tests__/prop_type_validation.js
+++ b/packages/reactabular-virtualized/src/__tests__/prop_type_validation.js
@@ -9,7 +9,7 @@ describe('height propType validator', function () {
     expect(heightPropCheck({ style: { maxHeight: 50 } }, 'height', 'VirtualizedBody')).toBeUndefined();
   });
 
-  it('has an error when height and style.maxHeight are not provided', function () {
+  it('has an error when height, container and style.maxHeight are not provided', function () {
     expect(heightPropCheck({}, 'height', 'VirtualizedBody')).toBeDefined();
   });
 
@@ -19,5 +19,9 @@ describe('height propType validator', function () {
 
   it('has an error when style.maxHeight is not a number', function () {
     expect(heightPropCheck({ style: { maxHeight: '50px' } }, 'height', 'VirtualizedBody')).toBeDefined();
+  });
+
+  it('has no error when container is provided', function () {
+    expect(heightPropCheck({ container: () => {} }, 'height', 'VirtualizedBody')).toBeUndefined();
   });
 });

--- a/packages/reactabular-virtualized/src/body.js
+++ b/packages/reactabular-virtualized/src/body.js
@@ -224,7 +224,7 @@ export function heightPropCheck(props, propName, componentName) {
     (!props.style || typeof props.style.maxHeight !== 'number') &&
     (!props.container || typeof props.container !== 'function')
   ) {
-    return new Error(`height or style.maxHeight of type 'number' or conatiner of type 'function' is marked as required in ${componentName}`);
+    return new Error(`height or style.maxHeight of type 'number' or container of type 'function' is marked as required in ${componentName}`);
   }
 
   return undefined;

--- a/packages/reactabular-virtualized/src/body.js
+++ b/packages/reactabular-virtualized/src/body.js
@@ -1,7 +1,8 @@
 import { isEqual } from 'lodash';
 import React from 'react';
 import { Body } from 'reactabular-sticky';
-import { resolveRowKey } from 'reactabular-table';
+import { resolveRowKey, Body as StandardBody } from 'reactabular-table';
+import PropTypes from 'prop-types';
 import { bodyChildContextTypes } from './types';
 import calculateAverageHeight from './calculate-average-height';
 import calculateRows from './calculate-rows';
@@ -9,6 +10,7 @@ import calculateRows from './calculate-rows';
 class VirtualizedBody extends React.Component {
   constructor(props) {
     super(props);
+
 
     this.measuredRows = {}; // row key -> measurement
     this.ref = null;
@@ -19,9 +21,16 @@ class VirtualizedBody extends React.Component {
     this.state = getInitialState();
 
     this.checkMeasurements = this.checkMeasurements.bind(this);
+    this.onScroll = this.onScroll.bind(this);
   }
   componentDidMount() {
     this.checkMeasurements();
+    this.props.container && this.registerContainer();
+  }
+  registerContainer() {
+    setTimeout(() => {
+      this.props.container().addEventListener('scroll', this.onScroll);
+    }, 0);
   }
   componentDidUpdate() {
     this.checkMeasurements();
@@ -33,13 +42,16 @@ class VirtualizedBody extends React.Component {
   getHeight(optionalProps) {
     // If `optionalProps` is defined, we use `optionalProps` instead of `this.props`.
     const props = optionalProps || this.props;
+    if (this.props.container) {
+      return this.props.container().clientHeight;
+    }
     // If `props.height` is not defined, we use `props.style.maxHeight` instead.
     return props.height || props.style.maxHeight;
   }
 
   componentWillReceiveProps(nextProps) {
     if (!isEqual(this.props.rows, nextProps.rows)
-        || this.getHeight() !== this.getHeight(nextProps)) {
+      || this.getHeight() !== this.getHeight(nextProps)) {
       if (process.env.NODE_ENV !== 'production' && typeof window !== 'undefined' && window.LOG_VIRTUALIZED) {
         console.log('invalidating measurements'); // eslint-disable-line no-console
       }
@@ -75,7 +87,7 @@ class VirtualizedBody extends React.Component {
   }
   render() {
     const {
-      onRow, rows, onScroll, ...props
+      onRow, rows, onScroll, container, ...props
     } = this.props;
     const { startIndex, amountOfRowsToRender } = this.state;
 
@@ -104,8 +116,9 @@ class VirtualizedBody extends React.Component {
       );
     }
 
+
     return React.createElement(
-      Body,
+      this.props.container ? StandardBody : Body,
       {
         ...props,
         onRow: (row, extra) => {
@@ -121,29 +134,31 @@ class VirtualizedBody extends React.Component {
         ref: (body) => {
           this.ref = body && body.getRef().getRef();
         },
-        onScroll: (e) => {
-          onScroll && onScroll(e);
-
-          const { target: { scrollTop } } = e;
-
-          // Y didn't change, bail to avoid rendering rows
-          if (this.scrollTop === scrollTop) {
-            return;
-          }
-
-          this.scrollTop = scrollTop;
-
-          this.setState(calculateRows({
-            scrollTop,
-            measuredRows: this.measuredRows,
-            height: this.getHeight(),
-            rowKey: this.props.rowKey,
-            rows: this.props.rows
-          }));
-        }
+        onScroll: this.onScroll
       }
     );
   }
+  onScroll(e) {
+    const { onScroll } = this.props;
+    onScroll && onScroll(e);
+
+    const { target: { scrollTop } } = e;
+
+    // Y didn't change, bail to avoid rendering rows
+    if (this.scrollTop === scrollTop) {
+      return;
+    }
+
+    this.scrollTop = this.props.container ? scrollTop - this.ref.parentElement.offsetTop : scrollTop;
+
+    this.setState(calculateRows({
+      scrollTop: this.scrollTop,
+      measuredRows: this.measuredRows,
+      height: this.getHeight(),
+      rowKey: this.props.rowKey,
+      rows: this.props.rows
+    }));
+  };
   getRef() {
     const { ref } = this;
 
@@ -198,16 +213,18 @@ class VirtualizedBody extends React.Component {
 VirtualizedBody.defaultProps = Body.defaultProps;
 VirtualizedBody.propTypes = {
   ...Body.propTypes,
-  height: heightPropCheck
+  height: heightPropCheck,
+  container: PropTypes.func
 };
 VirtualizedBody.childContextTypes = bodyChildContextTypes;
 
 export function heightPropCheck(props, propName, componentName) {
   if (
     (typeof props[propName] !== 'number') &&
-    (!props.style || typeof props.style.maxHeight !== 'number')
+    (!props.style || typeof props.style.maxHeight !== 'number') &&
+    (!props.container || typeof props.container !== 'function')
   ) {
-    return new Error(`height or style.maxHeight of type 'number' is marked as required in ${componentName}`);
+    return new Error(`height or style.maxHeight of type 'number' or conatiner of type 'function' is marked as required in ${componentName}`);
   }
 
   return undefined;

--- a/packages/reactabular-virtualized/src/calculate-rows.js
+++ b/packages/reactabular-virtualized/src/calculate-rows.js
@@ -13,9 +13,10 @@ const calculateRows = ({
   const amountOfRowsToRender = Math.ceil(height / averageHeight) + 2;
 
   const startIndex = Math.floor(scrollTop / averageHeight);
+  const zeroedIndex = Math.max(startIndex, 0);
   const rowsToRender = rows.slice(
-    startIndex,
-    startIndex + amountOfRowsToRender
+    zeroedIndex,
+    Math.max(startIndex + amountOfRowsToRender, 0)
   );
 
   if (process.env.NODE_ENV !== 'production' && typeof window !== 'undefined' && window.LOG_VIRTUALIZED) {
@@ -34,7 +35,7 @@ const calculateRows = ({
     return null;
   }
 
-  const startHeight = startIndex * averageHeight;
+  const startHeight = zeroedIndex * averageHeight;
 
   // Calculate the padding of the last row so we can match whole height. This
   // won't be totally accurate if row heights differ but should get close
@@ -60,8 +61,8 @@ const calculateRows = ({
 
   return {
     amountOfRowsToRender,
-    startIndex,
-    showExtraRow: !(startIndex % 2),
+    startIndex: zeroedIndex,
+    showExtraRow: !(zeroedIndex % 2),
     startHeight,
     endHeight
   };


### PR DESCRIPTION
Our designers want to be able to have tables scroll with the surrounding content in the page and have multiple tables in a list. This is tricky because some of the tables have thousands of entries and the designers are very against pagination. A natural solution was virtualization. So I added the ability to specify a container to use for scrolling and use that instead of creating a scrolling table inside of the component.

I tested for backward compatibility and it shouldn't break any existing tables, but an extra set of eyes on that is always a good thing 😄 .