### PR TITLE
fix(resizable): get class name

### DIFF
--- a/packages/reactabular-resizable/src/helper.js
+++ b/packages/reactabular-resizable/src/helper.js
@@ -60,7 +60,7 @@ function helper({ globalId, getId }) {
 }
 
 function getClassName(globalId, localId) {
-  return `column-${globalId}-${localId}`;
+  return `column-${globalId}-${localId}`.replace(/\./gi,'-');
 }
 
 function updateWidth({


### PR DESCRIPTION
Currently, nested columns do not have a width.
Changed to have width by changing class name.