### PR TITLE
add babel-polyfill so the docs run in IE11

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "babel-plugin-syntax-object-rest-spread": "^6.13.0",
     "babel-plugin-transform-object-rest-spread": "^6.22.0",
     "babel-plugin-transform-react-remove-prop-types": "^0.3.2",
+    "babel-polyfill": "^6.26.0",
     "babel-preset-es2015": "^6.22.0",
     "babel-preset-react": "^6.22.0",
     "catalog": "^3.2.3",

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -28,7 +28,7 @@ const packages = fromPairs(fs.readdirSync('packages').map(p => [
 ]));
 
 const common = {
-  entry: config.paths.documentation,
+  entry: ['babel-polyfill', config.paths.documentation],
   resolve: {
     extensions: ['.js', '.jsx', '.md', '.css', '.png', '.jpg'],
     alias: {
@@ -88,7 +88,6 @@ const commonSite = {
 };
 
 const developConfig = {
-  entry: config.paths.documentation,
   devServer: {
     historyApiFallback: true,
     hot: true,
@@ -111,9 +110,6 @@ const developConfig = {
 };
 
 const ghPagesConfig = {
-  entry: {
-    app: config.paths.documentation
-  },
   output: {
     path: config.paths.ghPages,
     filename: 'js/bundle.[chunkhash].js'


### PR DESCRIPTION
Currently the docs dont work in ie11 - both locally and live.
You just get a white screen with console error: SCRIPT438: Object doesn't support property or method 'assign'

I've added the babel-polyfill now to fix this.

