### PR TITLE
Fix the Virtualized example when running in Edge

### DIFF
--- a/packages/reactabular-virtualized/README.md
+++ b/packages/reactabular-virtualized/README.md
@@ -145,7 +145,8 @@ class VirtualizedTable extends React.Component {
             rows={rows}
             rowKey="id"
             style={{
-              maxWidth: 800
+              maxWidth: 800,
+              maxHeight: 400
             }}
             height={400}
             ref={tableBody => {


### PR DESCRIPTION
In Edge the first table in the virtualized page renders incorrectly (ie the height is not constrained)
![image](https://user-images.githubusercontent.com/14863246/66208475-135b6c00-e6ad-11e9-8567-43fcf04e04dc.png)

Fixed now:
![image](https://user-images.githubusercontent.com/14863246/66208533-2c641d00-e6ad-11e9-9c05-784fccb44f1a.png)

